### PR TITLE
Revert "Updated deps"

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "ribcage-preview": "./bin/cli.js"
   },
   "dependencies": {
-    "atomify": "^6.0.3"
+    "atomify": "^5.1.0",
+    "handlebars": "^1.3.0",
+    "hbsfy": "^1.3.2",
+    "resrcify": "^1.1.3"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Reverts Techwraith/ribcage-preview#8

This breaks for me with: ![](https://cloudup.com/cg2XUP2viU6+)

I know I'm the one who encouraged @mde to do this, but I don't remember why?
