### PR TITLE
Add support for serving HTML and JSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ ribcage-preview <dir>
 
 `<dir>` should be the directory of the component you want to preview.
 
-Create an `example` folder in your `<dir>` with an `entry.js` and an `entry.css`. All HTML should be created by `entry.js`.
+Create an `example` folder in your `<dir>` with an `entry.js` and an `entry.css` and optionally an `entry.html`.
+
+`.jsx` files are also recognized. If the index file is `.jsx`, client-side JS will be off by default unless you pass a `s` or `--client-jsx` flag. The `index.jsx` file is always rendered by the server and the results appended to `<div id=app>`. Your `example/entry.jsx` should render into the same `div`.
 
 ```sh
-open http://localhost:4000/default
+open http://localhost:4001/default
 ```
 
 This URL with livereload on every file change, and load in the compiled `entry.js` and `entry.css`.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
+'use strict'
 
 var server = require('../index.js')
+  , minimist = require('minimist')
+  , args = minimist(process.argv.slice(2))
   , path = require('path')
 
-server(path.join(process.cwd(), process.argv[2]))
+server({
+  dir: path.join(process.cwd(), args._[0])
+  , debug: args.d || args.debug
+  , enableClientJSX: args.s || args['client-jsx']
+})

--- a/index.js
+++ b/index.js
@@ -2,25 +2,95 @@
 
 var atomify = require('atomify')
   , path = require('path')
+  , fs = require('fs')
+  , React = require('react')
+  , babel = require('babel-core')
+  , internals = {}
 
-module.exports = function ribcagePreview (dir) {
-  atomify({
-    server: {
-      lr: {
-        patterns: [dir + '/**']
-      , port: 4001
+internals.findFirstFile = function findFirstFile (dir, filenames){
+  var entryPath
+    , i
+    , l
+
+  for (i = 0, l = filenames.length; i < l; i++){
+    entryPath = path.join(dir, filenames[i])
+    if (fs.existsSync(entryPath)){
+      return entryPath
+    }
+  }
+}
+
+internals.findEntryJs = function findEntryJs (dir){
+  return internals.findFirstFile(dir, ['entry.js', 'entry.jsx', 'index.js', 'index.jsx'])
+}
+
+internals.findEntryCss = function findEntryCss (dir){
+  return internals.findFirstFile(dir, ['entry.css', 'index.css'])
+}
+
+internals.findEntryHTML = function findEntryHTML (dir){
+  return internals.findFirstFile(dir, ['entry.html', 'index.html'])
+}
+
+module.exports = function ribcagePreview (options) {
+  var config = {
+      server: {
+        lr: {
+          port: 4001
+        }
+      , port: 4000
       }
-    , port: 4000
     }
-  , css: {
-      entry: path.join(dir, 'example/entry.css')
+    , exampleDir = path.join(options.dir, 'example')
+    , cssEntry = internals.findEntryCss(exampleDir)
+    , jsEntry = internals.findEntryJs(exampleDir)
+    , htmlEntry = internals.findEntryHTML(exampleDir)
+    , jsComponent = internals.findEntryJs(options.dir)
+
+  if (cssEntry) {
+    config.css = {
+      entry: cssEntry
     , alias: '/bundle.css'
-    , debug: true
+    , debug: options.debug
     }
-  , js: {
-      entry: path.join(dir, 'example/entry.js')
+  }
+
+  if (jsEntry) {
+    config.js = {
+      entry: jsEntry
     , alias: '/bundle.js'
-    , debug: true
+    , debug: options.debug
     }
-  })
+  }
+
+  if (htmlEntry) {
+    config.server.html = htmlEntry
+  }
+
+  if (jsEntry.indexOf('.jsx') > -1) {
+    config.server.html = function defaultHtml (paths, callback){
+      babel.transformFile(jsComponent, function es5dTheCode (err, result){
+        var reactComponent
+          // be sure to include the body tag so that the livereload snipped can
+          // be inserted
+          , html = '<body>'
+
+        if (err) return void callback(err)
+
+        // we'll get back a string of JS that needs to be run here, so … eval it
+        /* eslint-disable no-eval */
+        reactComponent = eval(result.code)
+        /* eslint-enable no-eval */
+
+        if (paths.css) html += '<link rel="stylesheet" href="' + paths.css + '" />'
+        html += '<div id="app">' + React.renderToString(React.createElement(reactComponent)) + '</div>'
+        if (paths.js && options.enableClientJSX) html += '<script src="' + paths.js + '"></script>'
+        html += '</body>'
+
+        callback(null, html)
+      })
+    }
+  }
+
+  atomify(config)
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "ribcage-preview": "./bin/cli.js"
   },
   "dependencies": {
-    "atomify": "^6.1.0"
+    "atomify": "^6.1.0",
+    "babel-core": "^5.1.10",
+    "minimist": "^1.1.1",
+    "react": "^0.13.1"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "ribcage-preview": "./bin/cli.js"
   },
   "dependencies": {
-    "atomify": "^6.1.0",
+    "atomify": "^7.0.0",
     "babel-core": "^5.1.10",
     "minimist": "^1.1.1",
     "react": "^0.13.1"


### PR DESCRIPTION
breaking: if used programatically, options is now an object instead of a
string.

Depends on https://github.com/atomify/atomify/pull/76